### PR TITLE
Update links from BBVA to OWASP

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ pitch: The vulnerability knowledge database
 ---
 ![Patton](/assets/images/patton-logo.png)
 
-[![GitHub Releases](https://img.shields.io/github/v/release/BBVA/patton?include_prereleases)](https://github.com/BBVA/patton/releases)
+[![GitHub Releases](https://img.shields.io/github/v/release/OWASP/Patton?include_prereleases)](https://github.com/OWASP/Patton/releases)
 
 ## Patton - The vulnerability knowledge database
 
@@ -38,8 +38,8 @@ a single interface to invoke all the tools in a consistent way.
 
 ## Contribution
 
-Everyone is welcome and encouraged to participate in our [Project](https://github.com/BBVA/patton).
+Everyone is welcome and encouraged to participate in our [Project](https://github.com/OWASP/Patton).
 
 ## Licensing
 
-This project is distributed under [Apache 2 license](https://github.com/bbva/patton/raw/master/LICENSE).
+This project is distributed under [Apache 2 license](https://github.com/OWASP/Patton/raw/master/LICENSE).

--- a/info.md
+++ b/info.md
@@ -7,16 +7,16 @@
 * [Home page](https://owasp.org/www-project-patton/)
 
 ### Downloads
-* [Patton releases](https://github.com/BBVA/patton/releases)
+* [Patton releases](https://github.com/OWASP/Patton/releases)
 <!-- * [Docker Image](https://hub.docker.com/r/bbvalabs/patton-server) -->
 
 
 ### Code Repository
-* [Github](https://github.com/BBVA/patton/)
+* [Github](https://github.com/OWASP/Patton/)
 
 ### Helping Patton!
-* [Report an issue](https://github.com/BBVA/patton/issues)
-<!-- * [Contributing to Patton](https://github.com/BBVA/patton/CONTRIBUTING) -->
+* [Report an issue](https://github.com/OWASP/Patton/issues)
+<!-- * [Contributing to Patton](https://github.com/OWASP/Patton/CONTRIBUTING) -->
 
 #### Classification
 

--- a/tab_examples.md
+++ b/tab_examples.md
@@ -22,8 +22,8 @@ After installing the dependencies run the following commands in order to finish
 the installation.
 
 ```bash
-$ wget https://github.com/BBVA/patton/releases/download/latest/patton.db.zst
-$ wget https://github.com/BBVA/patton/raw/develop/bin/patton
+$ wget https://github.com/OWASP/Patton/releases/download/latest/patton.db.zst
+$ wget https://github.com/OWASP/Patton/raw/develop/bin/patton
 $ install patton /usr/local/bin/patton
 ```
 


### PR DESCRIPTION
When browsing the published documentation I noticed that it linked to the archived repository. After some googling I found the currently active repo. 

Hopefully this updates all the links to the archived repository.